### PR TITLE
ci: update dependabot and ncurc configurations to match other nlds repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,36 @@
 version: 2
 
+# Documentation:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "main"
     versioning-strategy: "increase-if-necessary"
+    open-pull-requests-limit: 20
+    reviewers:
+      - "nl-design-system/sysadmin"
     ignore:
+      # We don't yet use Node 17 so the types of node should also be locked at 16.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
       # Stay at webpack 4 until webpack 5 is fully supported by Storybook
+      # Keep all related loader packes on the same major version too
       - dependency-name: "webpack"
         update-types: ["version-update:semver-major"]
-      # Stay at css-loader 5 which is compatible with webpack 4
       - dependency-name: "css-loader"
         update-types: ["version-update:semver-major"]
-      # Stay at style-loader 2 which is compatible with webpack 4
+      - dependency-name: "sass-loader"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "style-loader"
+        update-types: ["version-update:semver-major"]
+      # Percy needs a manual upgrade as it doesn't work without breaking
+      - dependency-name: "@percy/storybook"
         update-types: ["version-update:semver-major"]
       # Stay at React 16 until React 17 is fully supported by Storybook
       - dependency-name: "@types/react"
@@ -29,36 +44,54 @@ updates:
       # Stay at Angular 11 until manual upgrade to Angular 12
       - dependency-name: "@angular/cli"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular/compiler"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@angular/compiler-cli"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@angular/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular/forms"
         update-types: ["version-update:semver-major"]
       - dependency-name: "ng-packagr"
         update-types: ["version-update:semver-major"]
       - dependency-name: "rxjs"
         update-types: ["version-update:semver-major"]
       # `angular-devkit` follows unusual versioning rules.
-      # The important thing is to stay on a version matching Angular 11:
-      #
-      #     npm install --save-dev @angular-devkit/build-angular@v11-lts
+      # The important thing is to stay on a version matching Angular 11
       - dependency-name: "@angular-devkit/build-angular"
         update-types:
-          ["version-update:semver-major", "version-update:semver-minor"]
-      # Angular Compiler requires TypeScript >=4.0.0 and <4.2.0
+          [
+            "version-update:semver-major",
+            "version-update:semver-minor",
+            "version-update:semver-patch",
+          ]
+      # Angular 11 Compiler requires TypeScript >=4.0.0 and <4.2.0
       - dependency-name: "typescript"
         update-types:
           ["version-update:semver-major", "version-update:semver-minor"]
-
-  - package-ecosystem: "npm"
-    directory: "/documentation/"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    versioning-strategy: "increase-if-necessary"
-
-  - package-ecosystem: "npm"
-    directory: "/components/"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    versioning-strategy: "increase-if-necessary"
+      # Storybook 6.4 causes issues with the code samples in our stories.
+      # A fix and manual update is needed before upgrading.
+      - dependency-name: "@storybook/addon-a11y"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/addon-docs"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/addon-viewport"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/html"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/theming"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/builder-webpack5"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/cli"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@storybook/manager-webpack5"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]

--- a/.ncurc.major.js
+++ b/.ncurc.major.js
@@ -3,21 +3,30 @@ const minorConfig = require('./.ncurc.minor');
 module.exports = {
   reject: [
     ...minorConfig.reject,
+    // Angular needs to be upgraded in combination with Typescript
     '@angular/cli',
     '@angular/compiler',
     '@angular/compiler-cli',
     '@angular/core',
     '@angular/forms',
+    'rxjs',
+    'ng-packagr',
+    // Percy needs a manual upgrade as it doesn't work without breaking
     '@percy/storybook',
+    // Storybook needs React 16 to have support out of the box.
+    // Alternatively we could manually keep track of all sub-package versions,
+    // but the benefit of upgrading is currently not high enough.
+    'react',
+    'react-dom',
     '@types/react',
     '@types/react-dom',
     'css-loader',
-    'ng-packagr',
-    'react',
-    'react-dom',
-    'rxjs',
+    // Webpack 5 update can only happen after Storybook supports it, we'll need to do a manual upgrade then.
+    // For now keep the loader versions compatible with Webpack 4.
     'sass-loader',
     'style-loader',
     'webpack',
+    // We don't yet use Node 17 so the types of node should also be locked at 16.
+    '@types/node',
   ],
 };

--- a/.ncurc.minor.js
+++ b/.ncurc.minor.js
@@ -1,5 +1,18 @@
 const patchConfig = require('./.ncurc.patch');
 
 module.exports = {
-  reject: [...patchConfig.reject, 'typescript'],
+  reject: [
+    ...patchConfig.reject,
+    'typescript',
+    // Storybook 6.4 causes issues with the code samples in our stories.
+    // A fix and manual update is needed before upgrading.
+    '@storybook/addon-a11y',
+    '@storybook/addon-docs',
+    '@storybook/addon-viewport',
+    '@storybook/html',
+    '@storybook/theming',
+    '@storybook/builder-webpack5',
+    '@storybook/cli',
+    '@storybook/manager-webpack5',
+  ],
 };

--- a/.ncurc.patch.js
+++ b/.ncurc.patch.js
@@ -1,3 +1,7 @@
 module.exports = {
-  reject: ['@angular-devkit/build-angular'],
+  reject: [
+    // Angular needs to be upgraded in combination with Typescript.
+    // Somehow devkit is a patch version which matches the 11 major Angular package
+    '@angular-devkit/build-angular',
+  ],
 };


### PR DESCRIPTION
- [x] Add documentation to the ncurc configuration
- [x] Add ignore of major updates for `@types/node` 
- [x] Align Dependabot configuration with Utrecht and themes repo and remove unnecessary configurations for subfolders