### PR TITLE
ci: specify LF as line ending in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
When running Prettier pre-commit hook on Windows all files got the wrong file endings, this fixes that.