### PR TITLE
ci: use github organisation token

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -69,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_REPO_TOKEN }}
 
       - name: Set up Node.js version
         uses: actions/setup-node@v3.1.0
@@ -86,7 +88,7 @@ jobs:
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_AUTHOR_NAME: "NL Design System"
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}


### PR DESCRIPTION
- Use GH_REPO_TOKEN instead of GITHUB_TOKEN as this is not actually a supported secret name for GitHub
- Add `with GH_REPO_TOKEN` to the action to ensure availability of this token inside the action

<img width="297" alt="Screenshot 2022-08-02 at 10 44 04" src="https://user-images.githubusercontent.com/877246/182332542-fe112a81-e277-43eb-964d-4131f27a553f.png">

In the organisation we can now add repositories to the `GH_REPO_TOKEN` secret and every public repo has automatically access to the `GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_EMAIL`. For the npm secret we might not want to do it in the same way as it differs greatly from organisation to organisation?