### PR TITLE
build: update GitHub Actions

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,20 +12,20 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -34,24 +34,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: lint"
-        run: |
-          pnpm run --if-present lint
+        run: pnpm run --if-present lint
 
   build:
     runs-on: ubuntu-latest
@@ -59,45 +57,42 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Integration: lint build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present lint-build
+        run: pnpm run --if-present lint-build
 
       - name: "Continuous Integration: test build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present test-build
+        run: pnpm run --if-present test-build
 
-      - name: "Retain build artifact: storybook"
-        uses: actions/upload-artifact@v4.3.1
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          name: storybook
           path: packages/storybook/dist/
-          retention-days: 1
 
   test:
     runs-on: ubuntu-latest
@@ -105,45 +100,40 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: test"
-        run: |
-          pnpm run --if-present test
+        run: pnpm run --if-present test
 
   publish-website:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main'
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+
+    permissions:
+      pages: write
+      id-token: write
+
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v4.1.2
-
-      - name: "Restore build artifact: Storybook"
-        uses: actions/download-artifact@v4.1.4
-        with:
-          name: storybook
-          path: packages/storybook/dist/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          branch: gh-pages
-          folder: packages/storybook/dist/
+      - name: Deploy to GitHub Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   publish-npm:
     runs-on: ubuntu-latest
@@ -152,27 +142,26 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: "Continuous Deployment: install"
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
       - name: "Continuous Deployment: build"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:


### PR DESCRIPTION
Update actions to their latest versions and uses hashes to pin versions to prevent tampering. Tags are added as comments and both tags and hashes will be updated in Dependabot pull requests.

Add `--frozen-lockfile` to `pnpm install`s to make it explicit that this is what happens during ci.

Use GitHub's own actions to publish to GitHub Pages.

Depends on nl-design-system/terraform/pull/78