### PR TITLE
build: disable `publish-npm` job for nl-design-system/example

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -138,7 +138,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.repository != 'nl-design-system/example'
 
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
This repo does not publish anything to npm