### PR TITLE
build: group dependabot's storybook PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:


### PR DESCRIPTION
This makes sure that the `storybook` and `@storybook/*` dependencies are all updated in a single pull request instead instead of many that depend on one another anyway.