### PR TITLE
chore: update lint-staged config

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,0 @@
-{
-  "composer.json": "composer validate",
-  "package.json": "npmPkgJsonLint --allowEmptyTargets",
-  "*.md": ["markdownlint", "prettier --check"],
-  "*.{js,cjs,mjs,json,jsx,mdx,ts,tsx}": ["eslint --no-error-on-unmatched-pattern", "prettier --check"],
-  "*.{css,scss}": ["stylelint --allow-empty-input", "prettier --check"]
-}

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,5 @@ components/components.d.ts
 packages/web-components-stencil/loader
 packages/web-components-react/src/react-component-lib/
 packages/web-components-react/src/components.ts
+
+.*ignore

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  '*': 'prettier --write',
+  'package.json': 'npmPkgJsonLint --allowEmptyTargets',
+  '*.md': ['markdownlint'],
+  '*.{js,cjs,mjs,json,jsx,mdx,ts,tsx}': ['eslint --no-error-on-unmatched-pattern'],
+  '*.{css,scss}': ['stylelint --allow-empty-input'],
+};


### PR DESCRIPTION
Use `lint-staged.config.cjs` instead of `.lint-stagedrc.json`.

Since lint-staged will only run tools for matching targets so the command line options to deal with empty targets are never needed.

Run `prettier --write` for all files that Prettier can autofix. These fixes are added to the same commit instead of resulting in a new commit.