### PR TITLE
fix: lint-staged config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,4 +24,3 @@ packages/web-components-stencil/loader
 packages/web-components-react/src/react-component-lib/
 packages/web-components-react/src/components.ts
 
-.*ignore

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  '*': 'prettier --write',
+  '*': 'prettier --ignore-unknown --write',
   'package.json': 'npmPkgJsonLint --allowEmptyTargets',
   '*.md': ['markdownlint'],
   '*.{js,cjs,mjs,json,jsx,mdx,ts,tsx}': ['eslint --no-error-on-unmatched-pattern'],


### PR DESCRIPTION
Make sure Prettier ignores files that it does not have a parser for. Remove the line from `.prettierignore` that had the same effect but is now no longer relevant.