### PR TITLE
chore: dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,11 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      storybook:
-        patterns:
-          - "storybook"
-          - "@storybook/*"
+      patch-and-minor-dependencies:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:


### PR DESCRIPTION
Group all patch and minor version updates into one pull requests.

Dependabot pull requests are normally not merged because we use our own `pnpm update-patch/minor/major` scripts to create pull requests. Dependabot pull requests mainly serve as a reminder. This change should bring down the number of pull requests down significantly while still serving as a reminder.

For major version bumps Dependabot will still open individual pull requests.