### PR TITLE
build: pin @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    ignore:
+      dependency-name: "@types/node"
+      update-types:
+        - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "directory": "."
   },
   "engines": {
+    "//": "Update @types/node when updating the node version here",
     "node": "^20",
     "pnpm": "^9"
   },
@@ -23,7 +24,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "2.27.8",
-    "@types/node": "22.5.5",
+    "@types/node": "20.14.13",
     "@typescript-eslint/eslint-plugin": "8.6.0",
     "@typescript-eslint/parser": "8.6.0",
     "eslint": "8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 2.27.8
         version: 2.27.8
       '@types/node':
-        specifier: 22.5.5
-        version: 22.5.5
+        specifier: 20.14.13
+        version: 20.14.13
       '@typescript-eslint/eslint-plugin':
         specifier: 8.6.0
         version: 8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
@@ -2149,9 +2149,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@20.10.1':
-    resolution: {integrity: sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==}
 
   '@types/node@20.14.13':
     resolution: {integrity: sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==}
@@ -9444,10 +9441,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@20.10.1':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.14.13':
     dependencies:
       undici-types: 5.26.5
@@ -12132,7 +12125,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.10.1
+      '@types/node': 22.5.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3


### PR DESCRIPTION
Make sure @types/node is in line with the version of node used in the repository