### PR TITLE
feat: add new workflow

### DIFF
--- a/.github/workflows/fresh.md
+++ b/.github/workflows/fresh.md
@@ -1,0 +1,60 @@
+## Vers & Veilig
+
+Het is weer tijd voor de maandelijkse ronde “Vers & Veilig”
+
+## Patch dependencies
+
+- [ ] patch dependencies zijn bijgewerkt
+
+  ### Zo doe je dat
+
+  - [ ] Bekijk of `reject` in `.ncurc.patch.cjs` moet worden bijgewerkt.
+  - [ ] Draai
+
+    ```sh
+    pnpm run update-patch
+    pnpm run test-update
+    ```
+
+  - [ ] Voeg problematische dependencies toe aan `.ncurc.patch.cjs` onder `reject` en probeer het nog een keer.
+
+## Minor dependencies
+
+- [ ] minor dependencies zijn bijgewerkt
+
+  ### Zo doe je dat
+
+  - [ ] Bekijk of `reject` in `.ncurc.minor.cjs` moet worden bijgewerkt.
+  - [ ] Draai
+
+    ```sh
+    pnpm run update-minor
+    pnpm run test-update
+    ```
+
+  - [ ] Voeg problematische dependencies toe aan `.ncurc.minor.cjs` onder `reject` en probeer het nog een keer.
+
+## Major dependencies
+
+- [ ] major dependencies zijn bijgewerkt óf er is een issue aangemaakt
+
+  ### Zo doe je dat
+
+  - [ ] Bekijk of `reject` in `.ncurc.major.cjs` moet worden bijgewerkt.
+  - [ ] Draai
+
+    ```sh
+    pnpm run update-major
+    pnpm run test-update
+    ```
+
+  - [ ] Voeg problematische dependencies toe aan `.ncurc.major.cjs` onder `reject` en probeer het nog een keer.
+
+## Kwetsbaarheden
+
+- [ ] Dependabot alerts nagekeken voor kwestbaarheden
+
+  ### Zo doe je dat
+
+  - [ ] Open de [Dependabot alerts](../security/dependabot)
+  - [ ] Werk kwetsbaarheden bij of sluit kwetsbaarheden met een goede reden

--- a/.github/workflows/fresh.yml
+++ b/.github/workflows/fresh.yml
@@ -1,0 +1,34 @@
+naam: "Vers en veilig"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # at 01:01 on the first day of every month
+    - cron: "1 1 1 * *"
+
+env:
+  MAINTAINER: "nl-design-system/kernteam-maintainer"
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Find existing issue
+        id: find-existing-issue
+        run: |
+          EXISTING_ISSUE=$(gh issue list --author "app/github-actions" --state open --search "🛠 Vers en veilig" --limit 1 --json number --jq first.number)
+          echo "existing-issue=${EXISTING_ISSUE}" >> $GITHUB_OUTPUT
+
+      - name: Close existing issue
+        if: ${{ steps.find-existing-issue.outputs.existing-issue != '' }}
+        run: gh issue close ${{ steps.find-existing-issue.outputs.existing-issue }}
+
+      - name: Create new issue
+        run: gh issue create --title "🛠 Vers en veilig voor $(LC_ALL=nl_NL.UTF-8 date -u +'%B %Y')" --assignee "${MAINTAINER}" --label "dependencies" --body-file .github/workflows/fresh.md


### PR DESCRIPTION
Add a workflow that runs on the first of each month.

The workflow will first check if there is a previous open issue and if so close it.

Then it will create a new issue, label it, and assign it to the maintainer group that is responsible for maintenance in this repository.

Closes #812 