### PR TITLE
chore: fix filenames of preview.ts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ You need to have the following tools installed to run Storybook locally:
 3. Choose and register an npm organisation on [npmjs.com](https://www.npmjs.com/org/create), if you haven't already. This is very important to keep your project secure. The core NL Design System uses `@nl-design-system/`, and you can choose something for yourself. This prevents others from adding their code to your teams codebase.
 4. Modify all `package.json` files to use your npm organisation scope. Don't forget the locally linked packages under `devDependencies`. Find and replace all occurences of `@example/` in your project with `@your-organisation/`. Run `pnpm install` to install each package in under the new organisation directory in each `node_modules/`.
 5. Modify `.npmpackagejsonlintrc.json` to require your organisation scope in package names, by configuring the `valid-values-name-scope` property.
-6. Modify the imports in `/packages/storybook/config/preview.tsx` and `packages/web-components-stencil/src/button/index.scss` to use your prefix.
+6. Modify the imports in `/packages/storybook/config/preview.ts` and `packages/web-components-stencil/src/button/index.scss` to use your prefix.
 7. Modify `proprietary/design-tokens/style-dictionary.config.json` to output `.yourprefix-theme` instead of `.example-theme`.
-8. Modify `preview.tsx` to use `yourprefix-theme` instead of `example-theme` as default theme for Storybook stories.
+8. Modify `preview.ts` to use `yourprefix-theme` instead of `example-theme` as default theme for Storybook stories.
 
 ### Run storybook
 
@@ -71,7 +71,7 @@ To add a component implementation to storybook, we use the `<component-name>-sto
 - Declare a story for each component variation and bind the template
 - Declare the possible inputs, with types and a description in the `argTypes` property of the `Meta` component in `stories.mdx`.
 - Add an `Argstable` component in your `stories.mdx`
-- Optionally add a different `status` to the `Meta` parameters. The options and colors can be found in `storybook/config/preview.tsx`
+- Optionally add a different `status` to the `Meta` parameters. The options and colors can be found in `storybook/config/preview.ts`
 
 ### Configuring the GitHub repository
 


### PR DESCRIPTION
README referred to `preview.ts` as `preview.tsx`.