### PR TITLE
feat: make config files reusable

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
+ignore-scripts=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,8 @@ CHANGELOG.md
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+# pnpm using `pnpm config` is particular about the formatting of its workspace file
+pnpm-workspace.yaml
 
 
 # Ignore generated files from Stencil
@@ -25,3 +27,8 @@ packages/web-components-react/src/react-component-lib/
 packages/web-components-react/src/components.ts
 packages/web-components-react/src/stencil-generated
 packages/web-components-stencil/www/
+
+
+# Use `terraform fmt` to fix formatting issues in Terraform files
+*.tf
+*.hcl

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "url": "git@github.com:nl-design-system/example.git",
     "directory": "."
   },
-  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
+  "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=20 <=22",
-    "pnpm": "^10"
+    "pnpm": "^10.16.0"
   },
   "workspaces": [
     "./packages/*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ autoInstallPeers: false
 
 engineStrict: true
 
+minimumReleaseAge: 1440
+
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - esbuild


### PR DESCRIPTION
- Add a new pnpm config option `minimumReleaseAge` that adds an extra layer of protection against supply chain attacks. Only packages that have been available on the npm registry for at least a day (1440 minutes) can be installed. This can be overriden by adding `minimumReleaseAgeExclude` if needed.

- This new option has been available since pnpm v10.16.0 which is why package.json#engines.pnpm was also updated.

- Re-add .npmrc to prevent pre- and post-install scripts from running by accident if the user ever mistakenly used npm instead of pnpm.

- Add Terraform files to .prettierignore
- Make sure Prettier does not touch pnpm-workspace.yaml files
- 
Closes #874