### PR TITLE
docs: document .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,24 @@
-# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
-# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
-# pnpm approve-builds
+# Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
+auto-install-peers=false
+
+# Configure pnpm so that it will not install any package that claims to not be compatible with the current Node.js
+# version.
+engine-strict=true
+
+# This is an npm only setting. We do not use npm, but if it is run by accident, this setting prevents pre- and
+# post-install scripts from executing. This is aligns with pnpm's behaviour, where these scripts must be explicitly
+# approved with `pnpm approve-builds`.
 ignore-scripts=true
+
+# Configure pnpm so it only installs package versions that have been published on the npm registry for at least 24 hours
+# (1440 minutes). This helps mitigate the risk of supply chain attacks by avoiding newly published, potentially
+# malicious versions.
+minimum-release-age=1440
+
+# Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
+# versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.
+save-exact=true
+save-prefix=
+
+# Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
+strict-peer-dependencies=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,19 +3,7 @@ packages:
   - packages/*
   - proprietary/*
 
-autoInstallPeers: false
-
-engineStrict: true
-
-minimumReleaseAge: 1440
-
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - esbuild
   - sharp
-
-saveExact: true
-
-savePrefix: ""
-
-strictPeerDependencies: false


### PR DESCRIPTION
Because we want to prevent accidental use of *npm*, we have added `ignore-scripts=true` to .npmrc. The presence of .npmrc means that pnpm will also write configuration options to this file instead of to pnpm-workspace.yaml.

Because of this, configuration options were moved back to .npmrc from pnpm-workspace.yaml.

As a bonus, this allows us to document the settings.