### PR TITLE
chore: improve pnpm settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,24 +1,4 @@
-# Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
-auto-install-peers=false
-
-# Configure pnpm so that it will not install any package that claims to not be compatible with the current Node.js
-# version.
-engine-strict=true
-
 # This is an npm only setting. We do not use npm, but if it is run by accident, this setting prevents pre- and
 # post-install scripts from executing. This is aligns with pnpm's behaviour, where these scripts must be explicitly
 # approved with `pnpm approve-builds`.
 ignore-scripts=true
-
-# Configure pnpm so it only installs package versions that have been published on the npm registry for at least 24 hours
-# (1440 minutes). This helps mitigate the risk of supply chain attacks by avoiding newly published, potentially
-# malicious versions.
-minimum-release-age=1440
-
-# Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
-# versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.
-save-exact=true
-save-prefix=
-
-# Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
-strict-peer-dependencies=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,31 @@
-packages:
-  - components/**
-  - packages/*
-  - proprietary/*
+# Edit this file by hand. Using `pnpm config` reformats the file and removes all comments.
 
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - esbuild
-  - sharp
+packages:
+  - 'components/**'
+  - 'packages/*'
+  - 'proprietary/*'
+
+# Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
+autoInstallPeers: false
+
+# Configure pnpm so that it will not install any package that claims to not be compatible with the current Node.js
+# version.
+engineStrict: true
+
+# Configure pnpm so it only installs package versions that have been published on the npm registry for at least 24 hours
+# (1440 minutes). This helps mitigate the risk of supply chain attacks by avoiding newly published, potentially
+# malicious versions.
+minimumReleaseAge: 1440
+
+# Make an exception for trusted packages, notably our own
+minimumReleaseAgeExclude:
+  - '@nl-design-system/*'
+
+# Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
+# versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.
+saveExact: true
+savePrefix: ''
+
+# Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
+strictPeerDependencies: false
+


### PR DESCRIPTION
- Add `minimumReleaseAgeExclude` to make exceptions for our own (and trusted) packages.
- Move the pnpm specific settings back to pnpm-workspace.yaml because for some sub commands pnpm still uses npm under the hood and npm then complains about settings it does not know about.