### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/packages/storybook/vercel.json
+++ b/packages/storybook/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": "storybook",
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm run build",
-  "framework": "storybook",
-  "ignoreCommand": "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" || \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" ]]",
-  "installCommand": "pnpm install --frozen-lockfile",
-  "outputDirectory": "packages/storybook/dist"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm run build",
+  "framework": "storybook",
+  "ignoreCommand": "[[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" || \"$VERCEL_GIT_COMMIT_REF\" == \"gh-pages\" ]]",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "packages/storybook/dist"
+}


### PR DESCRIPTION
This PR moves the vercel configuration to `vercel.json`.

It is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.

Edit:
- the `vercel.json` location can be in root or somewhere else, if you have multiple apps in the same repo it makes sense to put it in the package dir (so this location will be the default for other repos).  You will have to configure the vercel project to point the root directory to this folder.
- There is a setting "Include files outside the root directory in the Build Step" that needs to be enabled.  By default this seems to be true, but unfortunately, this setting can only be changed in UI, not through terraform.
- moving the vercel.json to the package dir means that some auto-detection stops working, like Node version, but this can and should be configured in the project anyway
- disabling builds for gh-pages/dependabot can be done with `git.deploymentEnabled` so we remove the `ignoreCommand` setting
