### PR TITLE
ci: use "Other" as framework preset

### DIFF
--- a/packages/storybook/vercel.json
+++ b/packages/storybook/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm run build",
-  "framework": "storybook",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
Rationale: avoid relying on Vercel magic.
